### PR TITLE
读取多行艺术家标签

### DIFF
--- a/rust/src/api/tag_reader.rs
+++ b/rust/src/api/tag_reader.rs
@@ -181,14 +181,11 @@ impl Audio {
             .primary_tag()
             .or_else(|| tagged_file.first_tag())
         {
-            let artists: Vec<String> = tag
-                .get_strings(&ItemKey::TrackArtist)
-                .map(std::string::ToString::to_string)
-                .collect();
-            let artist = if artists.is_empty() {
+            let artist_strs: Vec<_> = tag.get_strings(&ItemKey::TrackArtist).collect();
+            let artist = if artist_strs.is_empty() {
                 UNKNOWN_COW.to_string()
             } else {
-                artists.join(";")
+                artist_strs.join("/")
             };
 
             return Some(Audio {

--- a/rust/src/api/tag_reader.rs
+++ b/rust/src/api/tag_reader.rs
@@ -181,12 +181,22 @@ impl Audio {
             .primary_tag()
             .or_else(|| tagged_file.first_tag())
         {
+            let artists: Vec<String> = tag
+                .get_strings(&ItemKey::TrackArtist)
+                .map(std::string::ToString::to_string)
+                .collect();
+            let artist = if artists.is_empty() {
+                UNKNOWN_COW.to_string()
+            } else {
+                artists.join(";")
+            };
+
             return Some(Audio {
                 title: tag
                     .title()
                     .unwrap_or(path.file_name()?.to_string_lossy())
                     .to_string(),
-                artist: tag.artist().unwrap_or(UNKNOWN_COW).to_string(),
+                artist,
                 album: tag.album().unwrap_or(UNKNOWN_COW).to_string(),
                 track: tag.track(),
                 duration: properties.duration().as_secs(),


### PR DESCRIPTION
#187 #
使用 lofty 读取音乐艺术家标签时，可以读取多行标签，将多个标签文本使用分隔符 ';' 进行分隔
在内容为空时保证与原来的 UNKNOWN 一致

要考虑其他的分隔符吗？