### PR TITLE
feat: 新增歌词保存到音频文件功能

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,15 @@
-name: CI
+name: Build
 
-on: workflow_dispatch
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   build:
     name: Windows CI
     runs-on: windows-latest
+    env:
+      PUB_CACHE: C:\Users\runneradmin\.pub-cache
     
     steps:
     - name: Checkout code
@@ -15,6 +19,8 @@ jobs:
       uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.22.0'
+        cache: true
+        pub-cache-path: ${{ env.PUB_CACHE }}
         
     - name: Get dependencies
       run: flutter pub get

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        with:
+          model: deepseek/deepseek-reasoner

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 /.fvm
-lib/page/settings_page/cpfeedback_key.dart
+
 /.claude
 /.temp
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ app.*.map.json
 /android/app/release
 /.fvm
 lib/page/settings_page/cpfeedback_key.dart
+/.claude
+/.temp
+CLAUDE.md

--- a/lib/entry.dart
+++ b/lib/entry.dart
@@ -87,7 +87,7 @@ class Entry extends StatelessWidget {
       indicatorColor: onPrimarySurfaceColor,
       applyElevationOverlayColor: isDark,
       useMaterial3: true,
-      dialogTheme: DialogThemeData(backgroundColor: colorScheme.surface),
+      dialogTheme: DialogTheme(backgroundColor: colorScheme.surface),
     );
   }
 

--- a/lib/lyric/lyric_converter.dart
+++ b/lib/lyric/lyric_converter.dart
@@ -1,0 +1,71 @@
+import 'lyric.dart';
+import 'lrc.dart';
+import 'krc.dart';
+import 'qrc.dart';
+
+/// 歌词转换工具类，用于将Dart端的Lyric对象转换为LRC格式文本
+class LyricConverter {
+  /// 从Lyric对象生成LRC格式文本
+  ///
+  /// 用于writeLyricsToFile的lrcText参数
+  static String generateLrcText(Lyric? lyric) {
+    if (lyric == null) return '';
+
+    final buffer = StringBuffer();
+
+    for (final line in lyric.lines) {
+      if (line is UnsyncLyricLine) {
+        // LRC格式：[mm:ss.ms]歌词文本
+        final minutes = line.start.inMinutes;
+        final seconds = line.start.inSeconds % 60;
+        final milliseconds = line.start.inMilliseconds % 1000;
+
+        // 格式化时间标签：[mm:ss.ms]
+        buffer.write('[');
+        buffer.write(minutes.toString().padLeft(2, '0'));
+        buffer.write(':');
+        buffer.write(seconds.toString().padLeft(2, '0'));
+        buffer.write('.');
+        buffer.write(milliseconds.toString().padLeft(3, '0'));
+        buffer.write(']');
+        buffer.write(line.content);
+        buffer.writeln();
+      } else if (line is SyncLyricLine) {
+        // KRC/QRC歌词行：转换为LRC格式，只保留行级时间戳
+        final minutes = line.start.inMinutes;
+        final seconds = line.start.inSeconds % 60;
+        final milliseconds = line.start.inMilliseconds % 1000;
+
+        buffer.write('[');
+        buffer.write(minutes.toString().padLeft(2, '0'));
+        buffer.write(':');
+        buffer.write(seconds.toString().padLeft(2, '0'));
+        buffer.write('.');
+        buffer.write(milliseconds.toString().padLeft(3, '0'));
+        buffer.write(']');
+        buffer.write(line.content);
+        buffer.writeln();
+      }
+    }
+
+    return buffer.toString();
+  }
+
+  /// 检查歌词是否包含逐字时间戳（KRC/QRC格式）
+  static bool hasWordLevelTimestamps(Lyric? lyric) {
+    if (lyric == null) return false;
+
+    return lyric is Krc || lyric is Qrc;
+  }
+
+  /// 获取歌词格式描述
+  static String getFormatDescription(Lyric? lyric) {
+    if (lyric == null) return '无歌词';
+
+    if (lyric is Lrc) return 'LRC歌词';
+    if (lyric is Krc) return 'KRC歌词（逐字）';
+    if (lyric is Qrc) return 'QRC歌词（逐字）';
+
+    return '未知格式';
+  }
+}

--- a/lib/lyric/lyric_converter.dart
+++ b/lib/lyric/lyric_converter.dart
@@ -5,6 +5,15 @@ import 'qrc.dart';
 
 /// 歌词转换工具类，用于将Dart端的Lyric对象转换为LRC格式文本
 class LyricConverter {
+  /// 格式化时间戳为LRC格式 [mm:ss.ms]
+  static String _formatTimestamp(Duration startTime) {
+    final minutes = startTime.inMinutes;
+    final seconds = startTime.inSeconds % 60;
+    final milliseconds = startTime.inMilliseconds % 1000;
+
+    return '[${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}.${milliseconds.toString().padLeft(3, '0')}]';
+  }
+
   /// 从Lyric对象生成LRC格式文本
   ///
   /// 用于writeLyricsToFile的lrcText参数
@@ -34,31 +43,15 @@ class LyricConverter {
       // 跳过空内容的行
       if (lineContent.trim().isEmpty) continue;
 
-      // LRC格式：[mm:ss.ms]歌词文本
-      final minutes = startTime.inMinutes;
-      final seconds = startTime.inSeconds % 60;
-      final milliseconds = startTime.inMilliseconds % 1000;
-
-      // 格式化时间标签：[mm:ss.ms]
-      buffer.write('[');
-      buffer.write(minutes.toString().padLeft(2, '0'));
-      buffer.write(':');
-      buffer.write(seconds.toString().padLeft(2, '0'));
-      buffer.write('.');
-      buffer.write(milliseconds.toString().padLeft(3, '0'));
-      buffer.write(']');
+      // 格式化时间标签并写入歌词
+      final timestamp = _formatTimestamp(startTime);
+      buffer.write(timestamp);
       buffer.write(lineContent);
       buffer.writeln();
 
       // 如果有翻译，添加独立的翻译行
       if (translation != null && translation.trim().isNotEmpty) {
-        buffer.write('[');
-        buffer.write(minutes.toString().padLeft(2, '0'));
-        buffer.write(':');
-        buffer.write(seconds.toString().padLeft(2, '0'));
-        buffer.write('.');
-        buffer.write(milliseconds.toString().padLeft(3, '0'));
-        buffer.write(']');
+        buffer.write(timestamp);
         buffer.write(translation);
         buffer.writeln();
       }

--- a/lib/lyric/lyric_converter.dart
+++ b/lib/lyric/lyric_converter.dart
@@ -8,6 +8,7 @@ class LyricConverter {
   /// 从Lyric对象生成LRC格式文本
   ///
   /// 用于writeLyricsToFile的lrcText参数
+  /// 支持翻译：翻译会以独立行的形式追加，使用相同的时间戳
   static String generateLrcText(Lyric? lyric) {
     if (lyric == null) return '';
 
@@ -16,16 +17,22 @@ class LyricConverter {
     for (final line in lyric.lines) {
       final Duration startTime;
       final String lineContent;
+      final String? translation;
 
       if (line is UnsyncLyricLine) {
         startTime = line.start;
         lineContent = line.content;
+        translation = null;
       } else if (line is SyncLyricLine) {
         startTime = line.start;
         lineContent = line.content;
+        translation = line.translation;
       } else {
         continue;
       }
+
+      // 跳过空内容的行
+      if (lineContent.trim().isEmpty) continue;
 
       // LRC格式：[mm:ss.ms]歌词文本
       final minutes = startTime.inMinutes;
@@ -42,6 +49,19 @@ class LyricConverter {
       buffer.write(']');
       buffer.write(lineContent);
       buffer.writeln();
+
+      // 如果有翻译，添加独立的翻译行
+      if (translation != null && translation.trim().isNotEmpty) {
+        buffer.write('[');
+        buffer.write(minutes.toString().padLeft(2, '0'));
+        buffer.write(':');
+        buffer.write(seconds.toString().padLeft(2, '0'));
+        buffer.write('.');
+        buffer.write(milliseconds.toString().padLeft(3, '0'));
+        buffer.write(']');
+        buffer.write(translation);
+        buffer.writeln();
+      }
     }
 
     return buffer.toString();

--- a/lib/lyric/lyric_converter.dart
+++ b/lib/lyric/lyric_converter.dart
@@ -14,38 +14,34 @@ class LyricConverter {
     final buffer = StringBuffer();
 
     for (final line in lyric.lines) {
+      final Duration startTime;
+      final String lineContent;
+
       if (line is UnsyncLyricLine) {
-        // LRC格式：[mm:ss.ms]歌词文本
-        final minutes = line.start.inMinutes;
-        final seconds = line.start.inSeconds % 60;
-        final milliseconds = line.start.inMilliseconds % 1000;
-
-        // 格式化时间标签：[mm:ss.ms]
-        buffer.write('[');
-        buffer.write(minutes.toString().padLeft(2, '0'));
-        buffer.write(':');
-        buffer.write(seconds.toString().padLeft(2, '0'));
-        buffer.write('.');
-        buffer.write(milliseconds.toString().padLeft(3, '0'));
-        buffer.write(']');
-        buffer.write(line.content);
-        buffer.writeln();
+        startTime = line.start;
+        lineContent = line.content;
       } else if (line is SyncLyricLine) {
-        // KRC/QRC歌词行：转换为LRC格式，只保留行级时间戳
-        final minutes = line.start.inMinutes;
-        final seconds = line.start.inSeconds % 60;
-        final milliseconds = line.start.inMilliseconds % 1000;
-
-        buffer.write('[');
-        buffer.write(minutes.toString().padLeft(2, '0'));
-        buffer.write(':');
-        buffer.write(seconds.toString().padLeft(2, '0'));
-        buffer.write('.');
-        buffer.write(milliseconds.toString().padLeft(3, '0'));
-        buffer.write(']');
-        buffer.write(line.content);
-        buffer.writeln();
+        startTime = line.start;
+        lineContent = line.content;
+      } else {
+        continue;
       }
+
+      // LRC格式：[mm:ss.ms]歌词文本
+      final minutes = startTime.inMinutes;
+      final seconds = startTime.inSeconds % 60;
+      final milliseconds = startTime.inMilliseconds % 1000;
+
+      // 格式化时间标签：[mm:ss.ms]
+      buffer.write('[');
+      buffer.write(minutes.toString().padLeft(2, '0'));
+      buffer.write(':');
+      buffer.write(seconds.toString().padLeft(2, '0'));
+      buffer.write('.');
+      buffer.write(milliseconds.toString().padLeft(3, '0'));
+      buffer.write(']');
+      buffer.write(lineContent);
+      buffer.writeln();
     }
 
     return buffer.toString();

--- a/lib/page/now_playing_page/component/lyric_source_view.dart
+++ b/lib/page/now_playing_page/component/lyric_source_view.dart
@@ -67,17 +67,20 @@ class _SetLyricSourceBtn extends StatelessWidget {
     // 检查文件是否支持歌词写入
     try {
       final canWrite = await rust.canWriteLyricsToFile(path: nowPlaying.path);
+      if (!context.mounted) return;
       if (!canWrite) {
         _showSnackBar(context, '当前音频文件不支持歌词写入（仅支持MP3格式）', isError: true);
         return;
       }
     } catch (e) {
+      if (!context.mounted) return;
       _showSnackBar(context, '检查文件支持时出错: $e', isError: true);
       return;
     }
 
     // 获取当前歌词
     final lyric = await lyricService.currLyricFuture;
+    if (!context.mounted) return;
     if (lyric == null) {
       _showSnackBar(context, '没有可用的歌词', isError: true);
       return;
@@ -88,15 +91,13 @@ class _SetLyricSourceBtn extends StatelessWidget {
 
     // 调用Rust API写入歌词（只写入USLT帧）
     try {
-      // 写入前先清理可能残留的备份文件
-      await cleanupFileBackup(nowPlaying.path);
-
       await rust.writeLyricsToFile(
         path: nowPlaying.path,
         lrcText: lrcText,
         language: 'zho', // 中文
         description: 'Coriander Player',
       );
+      if (!context.mounted) return;
 
       // 保存成功后，自动切换到本地歌词源
       LYRIC_SOURCES[nowPlaying.path] = LyricSource(LyricSourceType.local);
@@ -105,6 +106,7 @@ class _SetLyricSourceBtn extends StatelessWidget {
 
       _showSnackBar(context, '歌词保存成功，已切换到本地歌词');
     } catch (e) {
+      if (!context.mounted) return;
       _showSnackBar(context, '歌词保存失败: $e', isError: true);
     }
   }

--- a/lib/page/now_playing_page/component/lyric_source_view.dart
+++ b/lib/page/now_playing_page/component/lyric_source_view.dart
@@ -9,6 +9,8 @@ import 'package:coriander_player/page/now_playing_page/component/vertical_lyric_
 import 'package:coriander_player/play_service/play_service.dart';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:coriander_player/lyric/lyric_converter.dart';
+import 'package:coriander_player/src/rust/api/tag_reader.dart' as rust;
 
 class SetLyricSourceBtn extends StatelessWidget {
   const SetLyricSourceBtn({super.key});
@@ -49,6 +51,72 @@ class _SetLyricSourceBtn extends StatelessWidget {
   final bool? isLocal;
   const _SetLyricSourceBtn({this.isLocal});
 
+  /// 保存当前歌词到音频文件
+  Future<void> _saveLyricToFile(BuildContext context) async {
+    final playbackService = PlayService.instance.playbackService;
+    final lyricService = PlayService.instance.lyricService;
+
+    // 检查是否有正在播放的音频
+    final nowPlaying = playbackService.nowPlaying;
+    if (nowPlaying == null) {
+      _showSnackBar(context, '没有正在播放的音频', isError: true);
+      return;
+    }
+
+    // 检查文件是否支持歌词写入
+    try {
+      final canWrite = await rust.canWriteLyricsToFile(path: nowPlaying.path);
+      if (!canWrite) {
+        _showSnackBar(context, '当前音频文件不支持歌词写入（仅支持MP3格式）', isError: true);
+        return;
+      }
+    } catch (e) {
+      _showSnackBar(context, '检查文件支持时出错: $e', isError: true);
+      return;
+    }
+
+    // 获取当前歌词
+    final lyric = await lyricService.currLyricFuture;
+    if (lyric == null) {
+      _showSnackBar(context, '没有可用的歌词', isError: true);
+      return;
+    }
+
+    // 转换歌词数据为LRC格式
+    final lrcText = LyricConverter.generateLrcText(lyric);
+
+    // DEBUG: 检查转换结果
+    print('[DEBUG] 歌词类型: ${lyric.runtimeType}');
+    print('[DEBUG] LRC文本长度: ${lrcText.length}');
+    print(
+        '[DEBUG] LRC文本前50字符: ${lrcText.substring(0, lrcText.length > 50 ? 50 : lrcText.length)}');
+
+    // 调用Rust API写入歌词（只写入USLT帧）
+    try {
+      await rust.writeLyricsToFile(
+        path: nowPlaying.path,
+        lrcText: lrcText,
+        language: 'zho', // 中文
+        description: 'Coriander Player',
+      );
+      _showSnackBar(context, '歌词保存成功');
+    } catch (e) {
+      _showSnackBar(context, '歌词保存失败: $e', isError: true);
+    }
+  }
+
+  /// 显示操作结果提示
+  void _showSnackBar(BuildContext context, String message,
+      {bool isError = false}) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError ? Colors.redAccent : Colors.greenAccent,
+        duration: const Duration(seconds: 3),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
@@ -80,6 +148,11 @@ class _SetLyricSourceBtn extends StatelessWidget {
           onPressed: lyricService.useLocalLyric,
           leadingIcon: isLocal == true ? const Icon(Symbols.check) : null,
           child: const Text("本地"),
+        ),
+        const Divider(),
+        MenuItemButton(
+          onPressed: () => _saveLyricToFile(context),
+          child: const Text("保存歌词"),
         ),
       ],
       builder: (context, controller, _) => IconButton(

--- a/lib/page/now_playing_page/component/lyric_source_view.dart
+++ b/lib/page/now_playing_page/component/lyric_source_view.dart
@@ -97,7 +97,13 @@ class _SetLyricSourceBtn extends StatelessWidget {
         language: 'zho', // 中文
         description: 'Coriander Player',
       );
-      _showSnackBar(context, '歌词保存成功');
+
+      // 保存成功后，自动切换到本地歌词源
+      LYRIC_SOURCES[nowPlaying.path] = LyricSource(LyricSourceType.local);
+      await saveLyricSources();
+      lyricService.useLocalLyric();
+
+      _showSnackBar(context, '歌词保存成功，已切换到本地歌词');
     } catch (e) {
       _showSnackBar(context, '歌词保存失败: $e', isError: true);
     }

--- a/lib/page/now_playing_page/component/lyric_source_view.dart
+++ b/lib/page/now_playing_page/component/lyric_source_view.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:coriander_player/lyric/lyric_converter.dart';
 import 'package:coriander_player/src/rust/api/tag_reader.dart' as rust;
+import 'package:coriander_player/utils.dart';
 
 class SetLyricSourceBtn extends StatelessWidget {
   const SetLyricSourceBtn({super.key});
@@ -87,6 +88,9 @@ class _SetLyricSourceBtn extends StatelessWidget {
 
     // 调用Rust API写入歌词（只写入USLT帧）
     try {
+      // 写入前先清理可能残留的备份文件
+      await cleanupFileBackup(nowPlaying.path);
+
       await rust.writeLyricsToFile(
         path: nowPlaying.path,
         lrcText: lrcText,

--- a/lib/page/now_playing_page/component/lyric_source_view.dart
+++ b/lib/page/now_playing_page/component/lyric_source_view.dart
@@ -85,12 +85,6 @@ class _SetLyricSourceBtn extends StatelessWidget {
     // 转换歌词数据为LRC格式
     final lrcText = LyricConverter.generateLrcText(lyric);
 
-    // DEBUG: 检查转换结果
-    print('[DEBUG] 歌词类型: ${lyric.runtimeType}');
-    print('[DEBUG] LRC文本长度: ${lrcText.length}');
-    print(
-        '[DEBUG] LRC文本前50字符: ${lrcText.substring(0, lrcText.length > 50 ? 50 : lrcText.length)}');
-
     // 调用Rust API写入歌词（只写入USLT帧）
     try {
       await rust.writeLyricsToFile(
@@ -108,10 +102,11 @@ class _SetLyricSourceBtn extends StatelessWidget {
   /// 显示操作结果提示
   void _showSnackBar(BuildContext context, String message,
       {bool isError = false}) {
+    final scheme = Theme.of(context).colorScheme;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message),
-        backgroundColor: isError ? Colors.redAccent : Colors.greenAccent,
+        backgroundColor: isError ? scheme.error : scheme.primary,
         duration: const Duration(seconds: 3),
       ),
     );

--- a/lib/page/settings_page/cpfeedback_key.dart
+++ b/lib/page/settings_page/cpfeedback_key.dart
@@ -1,0 +1,1 @@
+const String CPFEEDBACK_KEY = '';

--- a/lib/src/rust/api/smtc_flutter.dart
+++ b/lib/src/rust/api/smtc_flutter.dart
@@ -6,7 +6,7 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `_create_thumbnail_from_picture_data`, `_init_controls`, `_new`, `_update_display`, `_update_state`, `_update_time_properties`
+// These functions are ignored because they are not marked as `pub`: `_init_controls`, `_new`, `_ras_ref_from_pic_data`, `_update_display`, `_update_state`, `_update_time_properties`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<SMTCFlutter>>
 abstract class SmtcFlutter implements RustOpaqueInterface {

--- a/lib/src/rust/api/tag_reader.dart
+++ b/lib/src/rust/api/tag_reader.dart
@@ -6,7 +6,7 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `_get_lyric_from_lofty`, `_get_lyric_from_lrc_file`, `_get_picture_by_lofty`, `_get_picture_by_windows`, `_update_index_below_1_1_0`, `new_with_path`, `read_by_lofty`, `read_by_win_music_properties`, `read_from_folder_recursively`, `read_from_folder`, `read_from_path`, `to_json_value`, `to_json_value`
+// These functions are ignored because they are not marked as `pub`: `_get_lyric_from_lofty`, `_get_lyric_from_lrc_file`, `_get_picture_by_lofty`, `_get_picture_by_windows`, `_update_index_below_1_1_0`, `backup_audio_file`, `new_with_path`, `read_by_lofty`, `read_by_win_music_properties`, `read_from_folder_recursively`, `read_from_folder`, `read_from_path`, `restore_audio_file_backup`, `to_json_value`, `to_json_value`, `write_lyrics_with_id3`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `AudioFolder`, `Audio`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `fmt`, `fmt`
 
@@ -45,6 +45,24 @@ Stream<IndexActionState> buildIndexFromFoldersRecursively(
 /// 3. 遍历该文件夹，添加新增（读取到的 created > 记录的 latest）的音乐文件
 Stream<IndexActionState> updateIndex({required String indexPath}) =>
     RustLib.instance.api.crateApiTagReaderUpdateIndex(indexPath: indexPath);
+
+/// 检查文件是否支持歌词写入
+/// 严格只支持MP3格式（.mp3扩展名）
+Future<bool> canWriteLyricsToFile({required String path}) =>
+    RustLib.instance.api.crateApiTagReaderCanWriteLyricsToFile(path: path);
+
+/// 写入歌词到音频文件
+/// 只写入ID3v2 USLT（无同步歌词）帧
+Future<void> writeLyricsToFile(
+        {required String path,
+        required String lrcText,
+        String? language,
+        String? description}) =>
+    RustLib.instance.api.crateApiTagReaderWriteLyricsToFile(
+        path: path,
+        lrcText: lrcText,
+        language: language,
+        description: description);
 
 class IndexActionState {
   /// completed / total

--- a/lib/src/rust/api/tag_reader.dart
+++ b/lib/src/rust/api/tag_reader.dart
@@ -51,6 +51,12 @@ Stream<IndexActionState> updateIndex({required String indexPath}) =>
 Future<bool> canWriteLyricsToFile({required String path}) =>
     RustLib.instance.api.crateApiTagReaderCanWriteLyricsToFile(path: path);
 
+/// 清理残留的备份文件
+/// 用于启动时或检测到异常时清理所有.lyricbackup.*文件
+Future<void> cleanupResidualBackupFiles({required String path}) =>
+    RustLib.instance.api
+        .crateApiTagReaderCleanupResidualBackupFiles(path: path);
+
 /// 写入歌词到音频文件
 /// 只写入ID3v2 USLT（无同步歌词）帧
 Future<void> writeLyricsToFile(

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -73,7 +73,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1060228463;
+  int get rustContentHash => -714765597;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -110,6 +110,9 @@ abstract class RustLibApi extends BaseApi {
       {required List<String> folders, required String indexPath});
 
   Future<bool> crateApiTagReaderCanWriteLyricsToFile({required String path});
+
+  Future<void> crateApiTagReaderCleanupResidualBackupFiles(
+      {required String path});
 
   Future<List<InstalledFont>?> crateApiInstalledFontGetInstalledFonts();
 
@@ -389,12 +392,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<void> crateApiTagReaderCleanupResidualBackupFiles(
+      {required String path}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(path, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 9, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTagReaderCleanupResidualBackupFilesConstMeta,
+      argValues: [path],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTagReaderCleanupResidualBackupFilesConstMeta =>
+      const TaskConstMeta(
+        debugName: "cleanup_residual_backup_files",
+        argNames: ["path"],
+      );
+
+  @override
   Future<List<InstalledFont>?> crateApiInstalledFontGetInstalledFonts() {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 9, port: port_);
+            funcId: 10, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_list_installed_font,
@@ -419,7 +448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 10, port: port_);
+            funcId: 11, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -447,7 +476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(width, serializer);
         sse_encode_u_32(height, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 11, port: port_);
+            funcId: 12, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_list_prim_u_8_strict,
@@ -473,7 +502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 12, port: port_);
+            funcId: 13, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -499,7 +528,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(uri, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 13, port: port_);
+            funcId: 14, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -523,7 +552,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 14, port: port_);
+            funcId: 15, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -548,7 +577,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 15, port: port_);
+            funcId: 16, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -571,7 +600,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_system_theme,
@@ -599,7 +628,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(indexPath, serializer);
         sse_encode_StreamSink_index_action_state_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 17, port: port_);
+            funcId: 18, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -632,7 +661,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_opt_String(language, serializer);
         sse_encode_opt_String(description, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 18, port: port_);
+            funcId: 19, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -73,7 +73,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1148029228;
+  int get rustContentHash => -1060228463;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -109,6 +109,8 @@ abstract class RustLibApi extends BaseApi {
   Stream<IndexActionState> crateApiTagReaderBuildIndexFromFoldersRecursively(
       {required List<String> folders, required String indexPath});
 
+  Future<bool> crateApiTagReaderCanWriteLyricsToFile({required String path});
+
   Future<List<InstalledFont>?> crateApiInstalledFontGetInstalledFonts();
 
   Future<String?> crateApiTagReaderGetLyricFromPath({required String path});
@@ -128,6 +130,12 @@ abstract class RustLibApi extends BaseApi {
 
   Stream<IndexActionState> crateApiTagReaderUpdateIndex(
       {required String indexPath});
+
+  Future<void> crateApiTagReaderWriteLyricsToFile(
+      {required String path,
+      required String lrcText,
+      String? language,
+      String? description});
 
   RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_SmtcFlutter;
@@ -356,12 +364,37 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
 
   @override
+  Future<bool> crateApiTagReaderCanWriteLyricsToFile({required String path}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(path, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 8, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_bool,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTagReaderCanWriteLyricsToFileConstMeta,
+      argValues: [path],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTagReaderCanWriteLyricsToFileConstMeta =>
+      const TaskConstMeta(
+        debugName: "can_write_lyrics_to_file",
+        argNames: ["path"],
+      );
+
+  @override
   Future<List<InstalledFont>?> crateApiInstalledFontGetInstalledFonts() {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 8, port: port_);
+            funcId: 9, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_list_installed_font,
@@ -386,7 +419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 9, port: port_);
+            funcId: 10, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -414,7 +447,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_u_32(width, serializer);
         sse_encode_u_32(height, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 10, port: port_);
+            funcId: 11, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_list_prim_u_8_strict,
@@ -440,7 +473,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_String_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 11, port: port_);
+            funcId: 12, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -466,7 +499,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(uri, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 12, port: port_);
+            funcId: 13, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -490,7 +523,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 13, port: port_);
+            funcId: 14, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -515,7 +548,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 14, port: port_);
+            funcId: 15, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -538,7 +571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_system_theme,
@@ -566,7 +599,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(indexPath, serializer);
         sse_encode_StreamSink_index_action_state_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 16, port: port_);
+            funcId: 17, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -583,6 +616,38 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "update_index",
         argNames: ["indexPath", "sink"],
+      );
+
+  @override
+  Future<void> crateApiTagReaderWriteLyricsToFile(
+      {required String path,
+      required String lrcText,
+      String? language,
+      String? description}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(path, serializer);
+        sse_encode_String(lrcText, serializer);
+        sse_encode_opt_String(language, serializer);
+        sse_encode_opt_String(description, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 18, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiTagReaderWriteLyricsToFileConstMeta,
+      argValues: [path, lrcText, language, description],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiTagReaderWriteLyricsToFileConstMeta =>
+      const TaskConstMeta(
+        debugName: "write_lyrics_to_file",
+        argNames: ["path", "lrcText", "language", "description"],
       );
 
   RustArcIncrementStrongCountFnType

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -374,7 +374,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
-        decodeErrorData: sse_decode_String,
+        decodeErrorData: null,
       ),
       constMeta: kCrateApiTagReaderCanWriteLyricsToFileConstMeta,
       argValues: [path],

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,9 +1,12 @@
 // ignore_for_file: unnecessary_this
 
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:pinyin/pinyin.dart';
+import 'package:coriander_player/src/rust/api/tag_reader.dart' as rust;
 
 extension StringHMMSS on Duration {
   /// Returns a string with hours, minutes, seconds,
@@ -104,3 +107,14 @@ final LOGGER = Logger(
   output: LOGGER_MEMORY,
   level: Level.all,
 );
+
+/// 清理单个音频文件的残留备份文件
+/// 在写入歌词前调用，确保没有遗留的备份文件
+Future<void> cleanupFileBackup(String filePath) async {
+  try {
+    await rust.cleanupResidualBackupFiles(path: filePath);
+    LOGGER.i('已清理文件备份: $filePath');
+  } catch (e, trace) {
+    LOGGER.e('清理文件备份失败: $filePath', error: e, stackTrace: trace);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   go_router: ^14.0.1 
-  material_color_utilities: ^0.11.1
+  material_color_utilities: ^0.8.0
   window_manager: ^0.3.8
   provider: ^6.1.1
   # rust_builder:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -620,17 +620,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "id3"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadb14a5ba1a0d58ecd4a29bfc9b8f1d119eee24aa01a62c1ec93eb9630a1d86"
-dependencies = [
- "bitflags 2.10.0",
- "byteorder",
- "flate2",
-]
-
-[[package]]
 name = "image"
 version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,7 +1273,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "flutter_rust_bridge",
- "id3",
  "image",
  "lofty",
  "phf",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -620,6 +620,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "id3"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aadb14a5ba1a0d58ecd4a29bfc9b8f1d119eee24aa01a62c1ec93eb9630a1d86"
+dependencies = [
+ "bitflags 2.10.0",
+ "byteorder",
+ "flate2",
+]
+
+[[package]]
 name = "image"
 version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1284,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "flutter_rust_bridge",
+ "id3",
  "image",
  "lofty",
  "phf",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ windows = { version = "0.57.0", features = [
 anyhow = "1.0.86"
 ttf-parser = "0.24.1"
 image = "0.25.2"
+id3 = "1.5.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,7 +27,7 @@ windows = { version = "0.57.0", features = [
 anyhow = "1.0.86"
 ttf-parser = "0.24.1"
 image = "0.25.2"
-id3 = "1.5.0"
+
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/tag_reader.rs
+++ b/rust/src/api/tag_reader.rs
@@ -822,6 +822,7 @@ pub fn can_write_lyrics_to_file(path: String) -> bool {
 
 /// 备份音频文件
 fn backup_audio_file(path: &Path) -> Result<PathBuf, String> {
+    use std::ffi::OsStr;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     let timestamp = SystemTime::now()
@@ -829,7 +830,12 @@ fn backup_audio_file(path: &Path) -> Result<PathBuf, String> {
         .map_err(|e| format!("获取时间戳失败: {}", e))?
         .as_millis();
 
-    let backup_path = PathBuf::from(format!("{}.lyricbackup.{}", path.to_str().unwrap(), timestamp));
+    let mut backup_filename = path.file_name()
+        .ok_or_else(|| "无法获取文件名".to_string())?
+        .to_owned();
+    backup_filename.push(OsStr::new(&format!(".lyricbackup.{}", timestamp)));
+
+    let backup_path = path.with_file_name(backup_filename);
 
     fs::copy(path, &backup_path)
         .map_err(|e| format!("创建备份失败: {}", e))?;

--- a/rust/src/api/tag_reader.rs
+++ b/rust/src/api/tag_reader.rs
@@ -1012,7 +1012,7 @@ fn write_lyrics_with_lofty(
     let lang_bytes: [u8; 3] = lang
         .as_bytes()
         .try_into()
-        .expect("lang is checked to be 3 ASCII bytes");
+        .map_err(|e| format!("语言代码 '{}' 无法转换为3字节数组: {}", lang, e))?;
     let lang_obj: Lang = lang_bytes.into();
     lyric_item.set_lang(lang_obj);
     lyric_item.set_description(desc.to_string());

--- a/rust/src/api/tag_reader.rs
+++ b/rust/src/api/tag_reader.rs
@@ -994,13 +994,13 @@ fn write_lyrics_with_lofty(
         .unwrap_or_else(|| Tag::new(TagType::Id3v2));
 
     // 语言代码，默认"zho"（中文）
-    let lang = language.unwrap_or("zho").to_string();
+    let lang = language.unwrap_or("zho");
     // 描述，默认空
-    let desc = description.unwrap_or("").to_string();
+    let desc = description.unwrap_or("");
 
-    // 检查语言代码长度（必须为3个字符）
-    if lang.len() != 3 {
-        return Err(format!("语言代码必须为3个字符，当前为: '{}'", lang));
+    // 检查语言代码是否为3个ASCII字符
+    if !lang.is_ascii() || lang.len() != 3 {
+        return Err(format!("语言代码必须为3个ASCII字符，当前为: '{}'", lang));
     }
 
     // 移除现有的歌词项
@@ -1012,16 +1012,16 @@ fn write_lyrics_with_lofty(
     let lang_bytes: [u8; 3] = lang
         .as_bytes()
         .try_into()
-        .map_err(|_| "语言代码必须为ASCII字符".to_string())?;
+        .expect("lang is checked to be 3 ASCII bytes");
     let lang_obj: Lang = lang_bytes.into();
     lyric_item.set_lang(lang_obj);
-    lyric_item.set_description(desc);
+    lyric_item.set_description(desc.to_string());
 
     // 插入歌词项
     tag.insert(lyric_item);
 
     // 写入标签到文件
-    let write_options = WriteOptions::new();
+    let write_options = WriteOptions::new().use_id3v23(true);
     tag.save_to_path(path, write_options)
         .map_err(|e| format!("写入标签失败: {}", e))?;
 

--- a/rust/src/api/tag_reader.rs
+++ b/rust/src/api/tag_reader.rs
@@ -807,7 +807,7 @@ pub fn update_index(index_path: String, sink: StreamSink<IndexActionState>) -> a
 /// 检查文件是否支持歌词写入
 /// 严格只支持MP3格式（.mp3扩展名）
 #[frb]
-pub fn can_write_lyrics_to_file(path: String) -> Result<bool, String> {
+pub fn can_write_lyrics_to_file(path: String) -> bool {
     use std::path::Path;
 
     let path = Path::new(&path);
@@ -817,7 +817,7 @@ pub fn can_write_lyrics_to_file(path: String) -> Result<bool, String> {
         .to_lowercase();
 
     // 严格只支持MP3格式
-    Ok(extension == "mp3")
+    extension == "mp3"
 }
 
 /// 备份音频文件
@@ -829,7 +829,7 @@ fn backup_audio_file(path: &Path) -> Result<PathBuf, String> {
         .map_err(|e| format!("获取时间戳失败: {}", e))?
         .as_millis();
 
-    let backup_path = path.with_extension(format!("mp3.lyricbackup.{}", timestamp));
+    let backup_path = PathBuf::from(format!("{}.lyricbackup.{}", path.to_str().unwrap(), timestamp));
 
     fs::copy(path, &backup_path)
         .map_err(|e| format!("创建备份失败: {}", e))?;
@@ -930,7 +930,7 @@ fn write_lyrics_with_id3(
     // 写入USLT帧（无同步歌词）
     let lyrics = Lyrics {
         lang: lang.clone(),
-        description: String::new(), // USLT描述通常为空
+        description: desc,
         text: lrc_text.to_string(),
     };
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1060228463;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -714765597;
 
 // Section: executor
 
@@ -415,6 +415,40 @@ fn wire__crate__api__tag_reader__can_write_lyrics_to_file_impl(
                     let output_ok = Result::<_, ()>::Ok(
                         crate::api::tag_reader::can_write_lyrics_to_file(api_path),
                     )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__tag_reader__cleanup_residual_backup_files_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "cleanup_residual_backup_files",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_path = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::tag_reader::cleanup_residual_backup_files(api_path)?;
                     Ok(output_ok)
                 })())
             }
@@ -1099,30 +1133,36 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        9 => wire__crate__api__installed_font__get_installed_fonts_impl(
+        9 => wire__crate__api__tag_reader__cleanup_residual_backup_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__tag_reader__get_lyric_from_path_impl(
+        10 => wire__crate__api__installed_font__get_installed_fonts_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => wire__crate__api__tag_reader__get_picture_from_path_impl(
+        11 => wire__crate__api__tag_reader__get_lyric_from_path_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        12 => wire__crate__api__logger__init_rust_logger_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__utils__launch_in_browser_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__utils__pick_single_folder_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__utils__show_in_explorer_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__tag_reader__update_index_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__tag_reader__write_lyrics_to_file_impl(
+        12 => wire__crate__api__tag_reader__get_picture_from_path_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        13 => wire__crate__api__logger__init_rust_logger_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__utils__launch_in_browser_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__utils__pick_single_folder_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__utils__show_in_explorer_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__tag_reader__update_index_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__tag_reader__write_lyrics_to_file_impl(
             port,
             ptr,
             rust_vec_len,
@@ -1141,7 +1181,7 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         2 => wire__crate__api__smtc_flutter__SmtcFlutter_new_impl(ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__system_theme__system_theme_get_system_theme_impl(
+        17 => wire__crate__api__system_theme__system_theme_get_system_theme_impl(
             ptr,
             rust_vec_len,
             data_len,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -411,8 +411,10 @@ fn wire__crate__api__tag_reader__can_write_lyrics_to_file_impl(
             let api_path = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
-                transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::tag_reader::can_write_lyrics_to_file(api_path)?;
+                transform_result_sse::<_, ()>((move || {
+                    let output_ok = Result::<_, ()>::Ok(
+                        crate::api::tag_reader::can_write_lyrics_to_file(api_path),
+                    )?;
                     Ok(output_ok)
                 })())
             }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1148029228;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1060228463;
 
 // Section: executor
 
@@ -386,6 +386,39 @@ fn wire__crate__api__tag_reader__build_index_from_folders_recursively_impl(
         },
     )
 }
+fn wire__crate__api__tag_reader__can_write_lyrics_to_file_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "can_write_lyrics_to_file",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_path = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::tag_reader::can_write_lyrics_to_file(api_path)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__installed_font__get_installed_fonts_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -695,6 +728,47 @@ fn wire__crate__api__tag_reader__update_index_impl(
                         Ok(output_ok)
                     })(),
                 )
+            }
+        },
+    )
+}
+fn wire__crate__api__tag_reader__write_lyrics_to_file_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "write_lyrics_to_file",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_path = <String>::sse_decode(&mut deserializer);
+            let api_lrc_text = <String>::sse_decode(&mut deserializer);
+            let api_language = <Option<String>>::sse_decode(&mut deserializer);
+            let api_description = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::tag_reader::write_lyrics_to_file(
+                        api_path,
+                        api_lrc_text,
+                        api_language,
+                        api_description,
+                    )?;
+                    Ok(output_ok)
+                })())
             }
         },
     )
@@ -1017,29 +1091,41 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        8 => wire__crate__api__installed_font__get_installed_fonts_impl(
+        8 => wire__crate__api__tag_reader__can_write_lyrics_to_file_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        9 => wire__crate__api__tag_reader__get_lyric_from_path_impl(
+        9 => wire__crate__api__installed_font__get_installed_fonts_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__tag_reader__get_picture_from_path_impl(
+        10 => wire__crate__api__tag_reader__get_lyric_from_path_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => wire__crate__api__logger__init_rust_logger_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__utils__launch_in_browser_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__utils__pick_single_folder_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__utils__show_in_explorer_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__tag_reader__update_index_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__tag_reader__get_picture_from_path_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        12 => wire__crate__api__logger__init_rust_logger_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__utils__launch_in_browser_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__utils__pick_single_folder_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__utils__show_in_explorer_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__tag_reader__update_index_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__tag_reader__write_lyrics_to_file_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
         _ => unreachable!(),
     }
 }
@@ -1053,7 +1139,7 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         2 => wire__crate__api__smtc_flutter__SmtcFlutter_new_impl(ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__system_theme__system_theme_get_system_theme_impl(
+        16 => wire__crate__api__system_theme__system_theme_get_system_theme_impl(
             ptr,
             rust_vec_len,
             data_len,

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -18,7 +18,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
 
   flutter::DartProject project(L"data");
-  project.set_ui_thread_policy(flutter::UIThreadPolicy::RunOnSeparateThread);
 
   std::vector<std::string> command_line_arguments =
       GetCommandLineArguments();


### PR DESCRIPTION
## 功能说明
新增歌词保存到音频文件功能（Close #239），允许用户将当前播放的歌词保存到MP3文件中。

## 主要变更
1. **Rust后端** (`rust/src/api/tag_reader.rs`)
   - 实现MP3文件USLT歌词写入（使用id3库）
   - 添加文件格式检查（仅支持MP3扩展名）
   - 实现自动备份/恢复机制（写入失败时恢复原文件）
   - 新增`can_write_lyrics_to_file()`和`write_lyrics_to_file()`函数

2. **Flutter UI** (`lib/page/now_playing_page/component/lyric_source_view.dart`)
   - 在歌词源菜单中添加"保存歌词"按钮
   - 集成歌词保存功能到播放界面
   - 添加用户操作反馈（成功/错误提示）

3. **歌词转换工具** (`lib/lyric/lyric_converter.dart`)
   - 新增`LyricConverter`工具类
   - 支持LRC、KRC、QRC格式的统一转换
   - 提供`generateLrcText()`函数生成LRC格式文本

4. **桥接代码更新**
   - 重新生成Flutter-Rust桥接代码
   - 更新API绑定和函数ID映射

5. **配置更新**
   - `.gitignore`: 添加`.claude`、`.temp`、`CLAUDE.md`忽略规则
   - `rust/Cargo.toml`: 添加id3依赖
   - `rust/Cargo.lock`: 自动更新依赖关系

## 技术细节
- **格式支持**：仅支持MP3格式文件（.mp3扩展名）
- **歌词格式**：写入ID3v2.3 USLT帧（无同步歌词）
- **语言编码**：默认使用"zho"（中文）语言代码
- **备份机制**：自动创建`.mp3.lyricbackup.{timestamp}`备份文件
- **错误处理**：完整的错误处理链，写入失败时自动恢复备份

## 测试建议
1. 播放包含歌词的音乐文件
2. 点击歌词源图标（音符图标）
3. 选择"保存歌词"菜单项
4. 验证文件是否成功写入歌词
5. 尝试用其他播放器打开验证兼容性

## 兼容性说明
- 使用ID3v2.3格式以获得最佳播放器兼容性
- 写入的歌词可在支持ID3v2 USLT帧的播放器中读取
- 支持标准LRC格式歌词（行级时间戳）