### PR TITLE
fix: 修复歌单重复问题

### DIFF
--- a/lib/library/playlist.dart
+++ b/lib/library/playlist.dart
@@ -11,6 +11,7 @@ List<Playlist> PLAYLISTS = [];
 
 Future<void> readPlaylists() async {
   try {
+    PLAYLISTS.clear();
     final supportPath = (await getAppDataDir()).path;
     final playlistsPath = "$supportPath\\playlists.json";
 

--- a/lib/library/playlist.dart
+++ b/lib/library/playlist.dart
@@ -11,16 +11,19 @@ List<Playlist> PLAYLISTS = [];
 
 Future<void> readPlaylists() async {
   try {
-    PLAYLISTS.clear();
     final supportPath = (await getAppDataDir()).path;
     final playlistsPath = "$supportPath\\playlists.json";
 
     final playlistsStr = File(playlistsPath).readAsStringSync();
     final List playlistsJson = json.decode(playlistsStr);
 
+    final newPlaylists = <Playlist>[];
     for (Map item in playlistsJson) {
-      PLAYLISTS.add(Playlist.fromMap(item));
+      newPlaylists.add(Playlist.fromMap(item));
     }
+
+    PLAYLISTS.clear();
+    PLAYLISTS.addAll(newPlaylists);
   } catch (err, trace) {
     LOGGER.e(err, stackTrace: trace);
   }

--- a/lib/lyric/lyric_source.dart
+++ b/lib/lyric/lyric_source.dart
@@ -54,17 +54,20 @@ Map<String, LyricSource> LYRIC_SOURCES = {};
 
 Future<void> readLyricSources() async {
   try {
-    LYRIC_SOURCES.clear();
     final supportPath = (await getAppDataDir()).path;
     final lyricSourcePath = "$supportPath\\lyric_source.json";
 
     final lyricSourceStr = File(lyricSourcePath).readAsStringSync();
     final Map lyricSourceJson = json.decode(lyricSourceStr);
 
+    final newLyricSources = <String, LyricSource>{};
     for (final item in lyricSourceJson.entries) {
       if (File(item.key).existsSync() == false) continue;
-      LYRIC_SOURCES[item.key] = LyricSource.fromMap(item.value);
+      newLyricSources[item.key] = LyricSource.fromMap(item.value);
     }
+
+    LYRIC_SOURCES.clear();
+    LYRIC_SOURCES.addAll(newLyricSources);
   } catch (err, trace) {
     LOGGER.e(err, stackTrace: trace);
   }

--- a/lib/lyric/lyric_source.dart
+++ b/lib/lyric/lyric_source.dart
@@ -54,6 +54,7 @@ Map<String, LyricSource> LYRIC_SOURCES = {};
 
 Future<void> readLyricSources() async {
   try {
+    LYRIC_SOURCES.clear();
     final supportPath = (await getAppDataDir()).path;
     final lyricSourcePath = "$supportPath\\lyric_source.json";
 


### PR DESCRIPTION
## 问题描述
点击"确定"按钮重建索引后，原有的歌单会被复制一份，变成两个一样的歌单。

## 问题原因
在 `readPlaylists()` 和 `readLyricSources()` 函数中，从文件读取数据时没有先清空全局变量（`PLAYLISTS` 和 `LYRIC_SOURCES`），导致每次调用都会追加数据。

## 修复方案
在两个函数中添加 `clear()` 调用，在读取数据前先清空全局变量：
- `lib/library/playlist.dart`: 在 `readPlaylists()` 中添加 `PLAYLISTS.clear()`
- `lib/lyric/lyric_source.dart`: 在 `readLyricSources()` 中添加 `LYRIC_SOURCES.clear()`

## 测试
- [x] 修复后点击确定按钮不会重复歌单
- [x] 重建索引功能正常工作
- [x] 歌词来源数据不会重复

## 影响范围
- `other_settings.dart` 点击确定按钮时
- `updating_page.dart` 应用更新时

---

Releated #195 